### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/eshopdotnetcore.yml
+++ b/.github/workflows/eshopdotnetcore.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Test with dotnet
       run: dotnet test ./eShopOnWeb.sln --configuration Release
     - name: Publish Docker
-      uses: elgohr/Publish-Docker-Github-Action@2.12
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         # The name of the image you would like to push
         name: githubworkshop57119125.azurecr.io/eshopwebmvc


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore